### PR TITLE
Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 GCC_VER=$(shell gcc -dumpversion)
+ifeq ($(shell expr $(GCC_VER) \>= 4.2),1)
+    ADD_OPT+=-mtune=native
+endif
 ifeq ($(shell expr $(GCC_VER) \>= 4.5),1)
     ADD_OPT+=-fexcess-precision=fast
 endif
 # ----------------------------------------------------------------
 INC_DIR= -I../src -I../xbyak
 # -ffast-math option may generate bad code for fmath::expd
-CFLAGS += $(INC_DIR) -O3 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64 -DNDEBUG -fno-operator-names -msse2 -mfpmath=sse -mtune=native $(ADD_OPT) 
+CFLAGS += $(INC_DIR) -O3 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64 -DNDEBUG -fno-operator-names -msse2 -mfpmath=sse $(ADD_OPT) 
 CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith
 CFLAGS+=$(CFLAGS_WARN)
 LD=g++


### PR DESCRIPTION
- use more robust "gcc -dumpversion" instead of parsing the output of "gcc --version", strings like "4.6.2-x.y.z" cannot be compared by expr
- "-mtune=native" support is only available in GCC >= 4.2
