### PR TITLE
MinGW cross compilation support and __GNUC_PREREQ fix

### DIFF
--- a/fmath.hpp
+++ b/fmath.hpp
@@ -31,7 +31,7 @@
 #include <limits>
 #include <stdlib.h>
 #include <float.h>
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
 	#include <intrin.h>
 	#ifndef MIE_ALIGN
 		#define MIE_ALIGN(x) __declspec(align(x))


### PR DESCRIPTION
The first commit is related to the current xbyak pull request. The typo was accidently copied from xbyak/xbyak_util.h in one of my former pull requests.

The second commit adds MinGW cross compilation support, tested using GCC 4.6.2.
