### PR TITLE
fix exp_ps returns wrong value in the second and fourth slot.

### DIFF
--- a/fastexp.cpp
+++ b/fastexp.cpp
@@ -1049,9 +1049,27 @@ void testLimits()
 	}
 }
 
+void testSlots()
+{
+	float vals[4] = {0.1f, 20.0f, -20.0f, -40.0f};
+	float expvals[4] = {0.0f};
+	for (int i = 0; i < 4; i++) {
+		__m128 x = _mm_set_ps(vals[(i + 3) % 4], vals[(i + 2) % 4], vals[(i + 1) % 4], vals[(i + 0) % 4]);
+		_mm_storeu_ps(expvals, fmath::exp_ps(x));
+		for (int j = 0; j < 4; j++) {
+			int idx = (i + j) % 4;
+			float expect = fmath::exp(vals[idx]);
+			if (std::abs(expect - expvals[j]) > 1e-13f) {
+				printf("%d: expect[%d]=%.17g != shuffled[%d]=%.17g\n", i, idx, expect, j, expvals[j]);
+			}
+		}
+	}
+}
+
 int main()
 {
 	testLimits();
+	testSlots();
 	benchmark("std::exp    ", ::exp);
 	benchmark("fmath::expd ", fmath::expd);
 

--- a/fmath.hpp
+++ b/fmath.hpp
@@ -659,6 +659,7 @@ inline __m128 exp_ps(__m128 x)
 	t1 = _mm_movelh_ps(t1, t3);
 	t1 = _mm_castsi128_ps(_mm_slli_epi64(_mm_castps_si128(t1), 32));
 	t0 = _mm_movelh_ps(t0, t2);
+	t0 = _mm_castsi128_ps(_mm_srli_epi64(_mm_castps_si128(t0), 32));
 	t0 = _mm_or_ps(t0, t1);
 #else
 	__m128i ti = _mm_castps_si128(_mm_load_ss((const float*)&expVar.tbl[v0]));


### PR DESCRIPTION
I found a bug that fmath::exp_ps() (without Xbyak, without AVX2) returns wrong value in the second and fourth xmm slot, due to uncleared bits in second and fourth slot of "t0" variable.

shall be (at fmath.hpp:L661):
t1: [table3 0 table1 0]
t0: [0 table2 0 table0]
t1 OR t0: [table3 table2 table1 table0]

used to be:
t1: [table3 0 table1 0]
t0: [table2 table2 table0 table0] <- uncleared bits
t1 OR t0: [corrupt table2 corrupt table0]

this pull request contains:
- fix to the issue
- a test code to reproduce error in former versions and validate that the problem is fixed in current version: check that every slots will produce the same result to fmath::exp().