### PR TITLE
Add explicit check for clang to include x86intrin.h

### DIFF
--- a/fmath.hpp
+++ b/fmath.hpp
@@ -45,6 +45,10 @@
 	#if __GNUC_PREREQ(4, 4) || !defined(__GNUC__)
 		/* GCC >= 4.4 and non-GCC compilers */
 		#include <x86intrin.h>
+	#elif defined(__clang__) && __clang_major__ >= 3
+		// MJ: As far as I can tell, this has been available since at least clang version 3, but
+		// clang oftem masquerades as gcc 4.2, so the above gcc check doesn't get this right.
+		#include <x86intrin.h>
 	#elif __GNUC_PREREQ(4, 1)
 		/* GCC 4.1, 4.2, and 4.3 do not have x86intrin.h, directly include SSE2 header */
 		#include <emmintrin.h>


### PR DESCRIPTION
On my Mac, using clang (default system version from XCode) failed to compile code that includes "fmath.hpp" with errors like "error: unknown type name '__m256d'".

The problem is that clang tends to represent itself as some version of gcc.  In my case the macros are consistent with gcc 4.2, which means that fmath.hpp only includes "emmintrin.h", not "x86intrin.h".  However, clang nonetheless defines `__AVX2__`, so the compiler goes into that section and doesn't know what `__m256d` is.

This PR adds an explicit check for the clang compiler and includes "x86intrin.h" if appropriate.  I have it check for clang version >= 3, which I think is appropriate, although I haven't actually checked old versions.  Mine (from Apple) claims to be version 7, but I think it is equivalent to version 5 from llvm.  I looked through their release history, and it looks like they already had x86intrin.h support by [version 3](http://releases.llvm.org/3.0/docs/ReleaseNotes.html), so that's probably safe.