### PR TITLE
Dont assume expd_v size argument is a 2/4 multiple

### DIFF
--- a/fmath.hpp
+++ b/fmath.hpp
@@ -534,7 +534,7 @@ __m128i iaxL = _mm_castpd_si128(_mm_load_sd((const double*)&c.tbl[adr0]));
 
 /*
 	px : pointer to array of double
-	n : size of array(assume multiple of 2 or 4)
+	n : size of array
 */
 inline void expd_v(double *px, size_t n)
 {


### PR DESCRIPTION
This comment is misleading as the code treats well the remainder:

```
size_t r = n & 3;// AVX
size_t r = n & 1;// SSE
...
for (size_t i = 0; i < r; i++) {
		px[i] = expd(px[i]);
}

```